### PR TITLE
Fix MQTT discovery for buttons (now binary sensors with separate MQTT topics)

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -880,7 +880,7 @@ void HandleAndSendButtonPress(uint button, bool state)
     // Prüfen ob über MQTT versendet werden muss
     if (mqttAktiv == true && client.connected())
     {
-        client.publish((mqttMasterTopic + "buttons/button" + button).c_str(), String(state ? "true" : "false"), true);
+        client.publish((mqttMasterTopic + "buttons/button" + String(button)).c_str(), (state ? "true" : "false"), true);
     }
     // Prüfen ob über Websocket versendet werden muss
     if (webSocket.connectedClients() > 0)

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2456,7 +2456,7 @@ boolean MQTTreconnect()
                 payload = configPayloadTemplate;
                 payload.replace(F("#SENSORID#"), String(F("Button")) + String(n));
                 payload.replace(F("#SENSORNAME#"), String(btnLogNames[n]));
-                payload.replace(F("#STATETOPIC#"), String(F("buttons/button") + String(n)));
+                payload.replace(F("#STATETOPIC#"), String(F("buttons/button")) + String(n));
                 client.publish(topic.c_str(), payload.c_str(), true);
             }
         }

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2437,7 +2437,8 @@ boolean MQTTreconnect()
             "\"uniq_id\":\"#DEVICEID##SENSORID#\","
             "\"dev_cla\":\"timestamp\","
             "\"name\":\"#SENSORNAME#\","
-            "\"stat_t\":\"#MASTERTOPIC##STATETOPIC#\""
+            "\"stat_t\":\"#MASTERTOPIC##STATETOPIC#\","
+            "\"val_tpl\":\"{{value_json.#VALUENAME#}}\""
             "}"));
         configPayloadTemplate.replace(" ", "");
         configPayloadTemplate.replace(F("#DEVICEID#"), deviceID);
@@ -2456,8 +2457,9 @@ boolean MQTTreconnect()
 
                 payload = configPayloadTemplate;
                 payload.replace(F("#SENSORID#"), String(F("Button")) + String(n));
-                payload.replace(F("#SENSORNAME#"), String(F("Button")) + String(n));
-                payload.replace(F("#STATETOPIC#"), String(F("button")) + String(n));
+                payload.replace(F("#SENSORNAME#"), String(btnLogNames[n]));
+                payload.replace(F("#STATETOPIC#"), String(F("buttons")));
+                payload.replace(F("#VALUENAME#"), String(btnAPINames[n]));
                 client.publish(topic.c_str(), payload.c_str(), true);
             }
         }

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -880,7 +880,7 @@ void HandleAndSendButtonPress(uint button, bool state)
     // Prüfen ob über MQTT versendet werden muss
     if (mqttAktiv == true && client.connected())
     {
-        client.publish((mqttMasterTopic + "buttons").c_str(), String("{\"" + btnAPINames[button] + "\":" + (state ? "true" : "false") + "}").c_str(), true);
+        client.publish((mqttMasterTopic + "buttons/button" + button).c_str(), String(state ? "true" : "false"), true);
     }
     // Prüfen ob über Websocket versendet werden muss
     if (webSocket.connectedClients() > 0)
@@ -2436,8 +2436,7 @@ boolean MQTTreconnect()
             "\"pl_not_avail\":\"disconnected\","
             "\"uniq_id\":\"#DEVICEID##SENSORID#\","
             "\"name\":\"#SENSORNAME#\","
-            "\"stat_t\":\"#MASTERTOPIC##STATETOPIC#\","
-            "\"val_tpl\":\"{{value_json.#VALUENAME#}}\""
+            "\"stat_t\":\"#MASTERTOPIC##STATETOPIC#\""
             "}"));
         configPayloadTemplate.replace(" ", "");
         configPayloadTemplate.replace(F("#DEVICEID#"), deviceID);
@@ -2457,8 +2456,7 @@ boolean MQTTreconnect()
                 payload = configPayloadTemplate;
                 payload.replace(F("#SENSORID#"), String(F("Button")) + String(n));
                 payload.replace(F("#SENSORNAME#"), String(btnLogNames[n]));
-                payload.replace(F("#STATETOPIC#"), String(F("buttons")));
-                payload.replace(F("#VALUENAME#"), String(btnAPINames[n]));
+                payload.replace(F("#STATETOPIC#"), String(F("buttons/button") + String(n)));
                 client.publish(topic.c_str(), payload.c_str(), true);
             }
         }

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2435,7 +2435,6 @@ boolean MQTTreconnect()
             "\"pl_avail\":\"connected\","
             "\"pl_not_avail\":\"disconnected\","
             "\"uniq_id\":\"#DEVICEID##SENSORID#\","
-            "\"dev_cla\":\"timestamp\","
             "\"name\":\"#SENSORNAME#\","
             "\"stat_t\":\"#MASTERTOPIC##STATETOPIC#\","
             "\"val_tpl\":\"{{value_json.#VALUENAME#}}\""

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2436,6 +2436,9 @@ boolean MQTTreconnect()
             "\"pl_not_avail\":\"disconnected\","
             "\"uniq_id\":\"#DEVICEID##SENSORID#\","
             "\"name\":\"#SENSORNAME#\","
+            "\"ic\":\"mdi:gesture-tap-button\","
+            "\"pl_on\":\"true\","
+            "\"pl_off\":\"false\","
             "\"stat_t\":\"#MASTERTOPIC##STATETOPIC#\""
             "}"));
         configPayloadTemplate.replace(" ", "");
@@ -2450,7 +2453,7 @@ boolean MQTTreconnect()
             if (btnEnabled[n])
             {
                 topic = configTopicTemplate;
-                topic.replace(F("#COMPONENT#"), F("sensor"));
+                topic.replace(F("#COMPONENT#"), F("binary_sensor"));
                 topic.replace(F("#SENSORID#"), String(F("Button")) + String(n));
 
                 payload = configPayloadTemplate;


### PR DESCRIPTION
Fix MQTT discovery for buttons and change entity names for buttons, from Button0/1/2 to Left/Middle/Right Button.

Fixes #199.

Also changed the MQTT Discovery button entities from sensors to binary_sensors (with icon). This is a breaking change that causes the old non-working sensors to be kept and new working binary sensors to also appear. Removing the PixelIt device from MQTT Discovery integration should do the trick, as it will appear again automatically with only thee correct sensors..

Also allowed all button actions to co-exist (using different MQTT topic for each button). 