### PR TITLE
Do not show weekdays when returning to time

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2247,7 +2247,10 @@ void DrawClock(bool fromJSON)
                     DrawText(String(date), false, clockColorR, clockColorG, clockColorB, 7, (1 + counter));
                     DrawText(String(time), false, clockColorR, clockColorG, clockColorB, xPosTime, (-6 + counter));
                     matrix->drawLine(0, 7, 33, 7, 0);
-                    DrawWeekDay();
+                    if (clockDrawWeekDays)
+                    {
+                        DrawWeekDay();
+                    }
                     matrix->show();
                     delay(35);
                 }


### PR DESCRIPTION
If you disable the "Show weekdays" feature, weekdays will still be shown when the clock/date switch is active and the display returns from date to clock. The weekdays will be removed with the next update of the clock one second later.

This change keeps the weekdays from appearing.