### PR TITLE
Remove duplication from platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -95,20 +95,20 @@ lib_deps =
 	tzapu/WiFiManager@^0.16.0
 
 [env:ESP8266_d1_mini]
-extends = ESP8266_generic
+extends = env:ESP8266_generic
 monitor_filters = esp8266_exception_decoder
 board = d1_mini
 
 [env:ESP8266_nodemcuv2]
-extends = ESP8266_generic
+extends = env:ESP8266_generic
 board = nodemcuv2
 
 [env:ESP32_d1_mini32]
-extends = ESP32_generic
+extends = env:ESP32_generic
 board = wemos_d1_mini32
 
 [env:ESP32_ulanzi]
-extends = ESP32_generic
+extends = env:ESP32_generic
 build_flags =
 	${common.build_flags}
 	-DLDR_PIN=A7

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,7 +60,7 @@ build_flags =
 	-DDEFAULT_LDR=GL5516
 	-DVBAT_PIN=0
 platform_packages = 
- 	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
+ 	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.14
  	toolchain-xtensa32@~2.80400.0
 lib_deps = 
 	${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,59 +17,27 @@ build_flags =
 	-DMATRIX_WIDTH=32 ; Pixel cols
 	-DMATRIX_HEIGHT=8 ; Pixel rows
 lib_deps = 
-	links2004/WebSockets@^2.4.0
-	knolleary/PubSubClient@^2.8
-	bblanchon/ArduinoJson@^5.13.4
-	adafruit/Adafruit GFX Library@^1.10.5
-	fastled/FastLED@^3.4.0
-	beegee-tokyo/DHT sensor library for ESPx@^1.17
-	powerbroker2/DFPlayerMini_Fast@^1.2.0
-	adafruit/Adafruit BusIO@^1.7.2
 	adafruit/Adafruit BME280 Library@^2.0.2
-	adafruit/Adafruit BMP280 Library@^2.6.1
-	adafruit/Adafruit Unified Sensor@^1.1.4
-	LightDependentResistor=https://github.com/QuentinCG/Arduino-Light-Dependent-Resistor-Library.git
-	ColorConverter=https://github.com/luisllamasbinaburo/Arduino-ColorConverter.git
-	TimeLib = https://github.com/PaulStoffregen/Time.git
-	marcmerlin/FastLED NeoMatrix@^1.2
-	bakercp/CRC32 @ 2.0.0
-	adafruit/Adafruit SHT31 Library@^2.2.2
-
-[env:ESP32_d1_mini32]
-platform = espressif32
-board = wemos_d1_mini32
-framework = ${common.framework}
-board_build.f_cpu = 80000000L
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
-upload_speed = ${common.upload_speed}
-build_flags =
-	${common.build_flags}
-	-DLDR_PIN=A0
-	-DMATRIX_PIN=27
-	-DDEFAULT_PIN_SCL="Pin_D1"
-	-DDEFAULT_PIN_SDA="Pin_D3"
-	-DDEFAULT_PIN_DFPRX="Pin_D7"
-	-DDEFAULT_PIN_DFPTX="Pin_D8"
-	-DDEFAULT_PIN_ONEWIRE="Pin_D1"
-	-DDEFAULT_MATRIX_TYPE=1
-	-DDEFAULT_LDR=GL5516
-	-DVBAT_PIN=0
-platform_packages = 
- 	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
- 	toolchain-xtensa32@~2.80400.0
-lib_deps = 
-	${common.lib_deps}
-	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
-	plerup/EspSoftwareSerial@^6.11.4
-	fastled/FastLED@^3.5.0	
 	adafruit/Adafruit BME680 Library@^2.0.1
 	adafruit/Adafruit BMP280 Library@^2.6.1
-	claws/BH1750@^1.2.0
-	robtillaart/Max44009@^0.5.2
-	arduino-libraries/ArduinoHttpClient@^0.4.0
-	Hash = https://github.com/bbx10/Hash_tng.git
+	adafruit/Adafruit BusIO@^1.7.2
+	adafruit/Adafruit GFX Library@^1.10.5
 	adafruit/Adafruit SHT31 Library@^2.2.2
+	adafruit/Adafruit Unified Sensor@^1.1.4
+	arduino-libraries/ArduinoHttpClient@^0.4.0
+	bakercp/CRC32 @ 2.0.0
+	bblanchon/ArduinoJson@^5.13.4
+	beegee-tokyo/DHT sensor library for ESPx@^1.17
+	claws/BH1750@^1.2.0
+	ColorConverter=https://github.com/luisllamasbinaburo/Arduino-ColorConverter.git
+	fastled/FastLED@^3.4.0
+	knolleary/PubSubClient@^2.8
+	LightDependentResistor=https://github.com/QuentinCG/Arduino-Light-Dependent-Resistor-Library.git
+	links2004/WebSockets@^2.4.0
+	marcmerlin/FastLED NeoMatrix@^1.2
+	powerbroker2/DFPlayerMini_Fast@^1.2.0
+	robtillaart/Max44009@^0.5.2
+	TimeLib = https://github.com/PaulStoffregen/Time.git
 
 [env:ESP32_generic]
 platform = espressif32
@@ -96,16 +64,10 @@ platform_packages =
  	toolchain-xtensa32@~2.80400.0
 lib_deps = 
 	${common.lib_deps}
-	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
-	plerup/EspSoftwareSerial@^6.11.4
 	fastled/FastLED@^3.5.0	
-	adafruit/Adafruit BME680 Library@^2.0.1
-	adafruit/Adafruit BMP280 Library@^2.6.1
-	claws/BH1750@^1.2.0
-	robtillaart/Max44009@^0.5.2
-	arduino-libraries/ArduinoHttpClient@^0.4.0
 	Hash = https://github.com/bbx10/Hash_tng.git
-	adafruit/Adafruit SHT31 Library@^2.2.2
+	plerup/EspSoftwareSerial@^6.11.4
+	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
 
 [env:ESP8266_generic]
 platform = espressif8266@2.6.3
@@ -129,89 +91,24 @@ build_flags =
 	-DVBAT_PIN=0
 lib_deps = 
 	${common.lib_deps}
-	tzapu/WiFiManager@^0.16.0
-	adafruit/Adafruit BME680 Library@^2.0.1
-	adafruit/Adafruit BMP280 Library@^2.6.1
-	claws/BH1750@^1.2.0
-	robtillaart/Max44009@^0.5.2
-	arduino-libraries/ArduinoHttpClient@^0.4.0
 	mr-glt/SHA-1 Hash@^1.1.0
-	adafruit/Adafruit SHT31 Library@^2.2.2
+	tzapu/WiFiManager@^0.16.0
 
 [env:ESP8266_d1_mini]
-platform = espressif8266@2.6.3
+extends = ESP8266_generic
 monitor_filters = esp8266_exception_decoder
 board = d1_mini
-framework = ${common.framework}
-board_build.filesystem = littlefs
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
-upload_speed = ${common.upload_speed}
-build_flags =
- 	${common.build_flags}
- 	-DLDR_PIN=A0
-	-DMATRIX_PIN=D2
-	-DDEFAULT_PIN_SCL="Pin_D1"
-	-DDEFAULT_PIN_SDA="Pin_D3"
-	-DDEFAULT_PIN_DFPRX="Pin_D7"
-	-DDEFAULT_PIN_DFPTX="Pin_D8"
-	-DDEFAULT_PIN_ONEWIRE="Pin_D1"
-	-DDEFAULT_MATRIX_TYPE=1
-	-DDEFAULT_LDR=GL5516
-	-DVBAT_PIN=0
-lib_deps = 
-	${common.lib_deps}
-	tzapu/WiFiManager@^0.16.0
-	adafruit/Adafruit BME680 Library@^2.0.1
-	adafruit/Adafruit BMP280 Library@^2.6.1
-	claws/BH1750@^1.2.0
-	robtillaart/Max44009@^0.5.2
-	arduino-libraries/ArduinoHttpClient@^0.4.0
-	mr-glt/SHA-1 Hash@^1.1.0
-	adafruit/Adafruit SHT31 Library@^2.2.2
 
 [env:ESP8266_nodemcuv2]
-platform = espressif8266@2.6.3
+extends = ESP8266_generic
 board = nodemcuv2
-framework = ${common.framework}
-board_build.filesystem = littlefs
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
-upload_speed = ${common.upload_speed}
-build_flags =
- 	${common.build_flags}
- 	-DLDR_PIN=A0
-	-DMATRIX_PIN=D2
-	-DDEFAULT_PIN_SCL="Pin_D1"
-	-DDEFAULT_PIN_SDA="Pin_D3"
-	-DDEFAULT_PIN_DFPRX="Pin_D7"
-	-DDEFAULT_PIN_DFPTX="Pin_D8"
-	-DDEFAULT_PIN_ONEWIRE="Pin_D1"
-	-DDEFAULT_MATRIX_TYPE=1
-	-DDEFAULT_LDR=GL5516
-	-DVBAT_PIN=0
-lib_deps = 
-	${common.lib_deps}
-	tzapu/WiFiManager@^0.16.0
-	adafruit/Adafruit BME680 Library@^2.0.1
-	adafruit/Adafruit BMP280 Library@^2.6.1
-	claws/BH1750@^1.2.0
-	robtillaart/Max44009@^0.5.2
-	arduino-libraries/ArduinoHttpClient@^0.4.0
-	mr-glt/SHA-1 Hash@^1.1.0
-	adafruit/Adafruit SHT31 Library@^2.2.2
+
+[env:ESP32_d1_mini32]
+extends = ESP32_generic
+board = wemos_d1_mini32
 
 [env:ESP32_ulanzi]
-platform = espressif32
-board = esp32dev
-framework = ${common.framework}
-board_build.f_cpu = 80000000L
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
-upload_speed = ${common.upload_speed}
-platform_packages = 
-	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
-	toolchain-xtensa32@~2.80400.0
+extends = ESP32_generic
 build_flags =
 	${common.build_flags}
 	-DLDR_PIN=A7
@@ -227,16 +124,3 @@ build_flags =
 	-DDEFAULT_LDR=GL5516
 	-DMIN_BATTERY=475
 	-DMAX_BATTERY=665
-lib_deps = 
-	${common.lib_deps}
-	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
-	fastled/FastLED@^3.5.0	
-	arduino-libraries/ArduinoHttpClient@^0.4.0
-	adafruit/Adafruit SHT31 Library @ 2.2.0
-	Hash = https://github.com/bbx10/Hash_tng.git
-	plerup/EspSoftwareSerial@^6.11.4
-	adafruit/Adafruit BME680 Library@^2.0.1
-	adafruit/Adafruit BMP280 Library@^2.6.1
-	claws/BH1750@^1.2.0
-	robtillaart/Max44009@^0.5.2
-	adafruit/Adafruit SHT31 Library@^2.2.2


### PR DESCRIPTION
Currently, platformio.ini defines multiple environments which are very similar.

Changes in this PR:
* Use the `extends` option [1] to remove most duplication
* Sort library lists, move those used across all envs to the `common` environment
* Pin `framework-arduinoespressif32` to version 2.0.14 since master is unstable due to 3.0.0 release

[1] https://docs.platformio.org/en/latest/projectconf/sections/env/options/advanced/extends.html