### PR TITLE
Improve logging during pin assignment

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -3281,7 +3281,7 @@ LightDependentResistor::ePhotoCellKind TranslatePhotocell(String photocell)
         return LightDependentResistor::GL5539;
     if (photocell == "GL5549")
         return LightDependentResistor::GL5549;
-    Log(F("Zuordnung LDR"), F("Unbekannter LDR-Typ"));
+    Log(F("LDR assignment - unknown type"), photocell);
     return LightDependentResistor::GL5528;
 }
 
@@ -3308,7 +3308,7 @@ uint8_t TranslatePin(String pin)
         return D8;
     if (pin == "Pin_27")
         return 27;
-    Log(F("Pin-Zuordnung"), F("Unbekannter Pin"));
+    Log(F("Pin assignment - unknown pin"), pin);
     return LED_BUILTIN;
 #elif defined(ESP32)
 
@@ -3341,7 +3341,7 @@ uint8_t TranslatePin(String pin)
     if (pin == "SPI_CS0_GPIO_NUM")
         return SPI_CS0_GPIO_NUM;
 
-    Log(F("Pin-Zuordnung"), F("Unbekannter Pin"));
+    Log(F("Pin assignment - unknown pin"), pin);
     return GPIO_NUM_32; // IDK
 #endif
 }


### PR DESCRIPTION
When troubleshooting non-working buttons on PixelIt for Ulanzi I got the following vague message in logs:

```
Framebuffer_GFX::begin Width: 32 Height: 8 Num Pixels: 256
[1970-01-01T00:00:04] Pin-Zuordnung: Unbekannter Pin
```

This is a good hint that something is misconfigured, but logging can be improved.
With this commit, the log messagec now includes the unrecognized pin ID making it easier to find the root cause:

```
Framebuffer_GFX::begin Width: 32 Height: 8 Num Pixels: 256
[1970-01-01T00:00:04] Pin assignment - unknown pin: 11
```

Also applied the same improvement to LDR assignment error logs