### PR TITLE
Add large 8px non-bold clock font

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2415,6 +2415,13 @@ void DrawClock(bool fromJSON)
 
     int xPosTime = 0;
 
+    // check if a large font is in use
+    bool clockFontIsLarge = false;
+    if (clockLargeFont || clockFatFont)
+    {
+        clockFontIsLarge = true;
+    }
+
     if (clockDateDayMonth)
     {
         sprintf_P(date, PSTR("%02d.%02d."), day(), month());
@@ -2424,7 +2431,7 @@ void DrawClock(bool fromJSON)
         sprintf_P(date, PSTR("%02d/%02d"), month(), day());
     }
 
-    if (clock24Hours && clockWithSeconds && !clockFatFont && !clockLargeFont)
+    if (clock24Hours && clockWithSeconds && !clockFontIsLarge)
     {
         xPosTime = 2;
         sprintf_P(time, PSTR("%02d:%02d:%02d"), hour(), minute(), second());
@@ -2436,7 +2443,7 @@ void DrawClock(bool fromJSON)
         if (clockBlink && clockBlinkAnimated)
         {
             clockBlink = false;
-            if (!clockFatFont && !clockLargeFont)
+            if (!clockFontIsLarge)
             {
                 sprintf_P(time, PSTR("%2d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
             }
@@ -2448,7 +2455,7 @@ void DrawClock(bool fromJSON)
         else
         {
             clockBlink = !clockBlink;
-            if (!clockFatFont && !clockLargeFont)
+            if (!clockFontIsLarge)
             {
                 sprintf_P(time, PSTR("%2d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
             }
@@ -2488,7 +2495,7 @@ void DrawClock(bool fromJSON)
         {
             clockCounterDate = 0;
 
-            if (clockFatFont || clockLargeFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
+            if (clockFontIsLarge) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
             {
                 DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeOut(30);
@@ -2515,7 +2522,7 @@ void DrawClock(bool fromJSON)
                 }
             }
         }
-        else if (clockFatFont || clockLargeFont)
+        else if (clockFontIsLarge)
         {
 
             DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
@@ -2534,7 +2541,7 @@ void DrawClock(bool fromJSON)
         {
             clockCounterClock = 0;
 
-            if (clockFatFont || clockLargeFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
+            if (clockFontIsLarge) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
             {
                 DrawTextCenter(String(date), 2, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeOut(30);
@@ -2561,7 +2568,7 @@ void DrawClock(bool fromJSON)
                 }
             }
         }
-        else if (clockFatFont || clockLargeFont)
+        else if (clockFontIsLarge)
         {
             DrawTextCenter(String(date), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
         }
@@ -2571,7 +2578,7 @@ void DrawClock(bool fromJSON)
         }
     }
 
-    if (!clockFatFont && !clockLargeFont && clockDrawWeekDays)
+    if (!clockFontIsLarge && clockDrawWeekDays)
     {
         DrawWeekDay();
     }

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -2424,7 +2424,7 @@ void DrawClock(bool fromJSON)
         sprintf_P(date, PSTR("%02d/%02d"), month(), day());
     }
 
-    if (clock24Hours && clockWithSeconds && !clockFatFont)
+    if (clock24Hours && clockWithSeconds && !clockFatFont && !clockLargeFont)
     {
         xPosTime = 2;
         sprintf_P(time, PSTR("%02d:%02d:%02d"), hour(), minute(), second());
@@ -2436,7 +2436,7 @@ void DrawClock(bool fromJSON)
         if (clockBlink && clockBlinkAnimated)
         {
             clockBlink = false;
-            if (!clockFatFont)
+            if (!clockFatFont && !clockLargeFont)
             {
                 sprintf_P(time, PSTR("%2d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
             }
@@ -2448,7 +2448,7 @@ void DrawClock(bool fromJSON)
         else
         {
             clockBlink = !clockBlink;
-            if (!clockFatFont)
+            if (!clockFatFont && !clockLargeFont)
             {
                 sprintf_P(time, PSTR("%2d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
             }
@@ -2488,7 +2488,7 @@ void DrawClock(bool fromJSON)
         {
             clockCounterDate = 0;
 
-            if (clockFatFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
+            if (clockFatFont || clockLargeFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
             {
                 DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeOut(30);
@@ -2515,7 +2515,7 @@ void DrawClock(bool fromJSON)
                 }
             }
         }
-        else if (clockFatFont)
+        else if (clockFatFont || clockLargeFont)
         {
 
             DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
@@ -2534,7 +2534,7 @@ void DrawClock(bool fromJSON)
         {
             clockCounterClock = 0;
 
-            if (clockFatFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
+            if (clockFatFont || clockLargeFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
             {
                 DrawTextCenter(String(date), 2, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeOut(30);
@@ -2561,9 +2561,9 @@ void DrawClock(bool fromJSON)
                 }
             }
         }
-        else if (clockFatFont)
+        else if (clockFatFont || clockLargeFont)
         {
-            DrawTextCenter(String(date), 2, clockColorR, clockColorG, clockColorB, 0, 1);
+            DrawTextCenter(String(date), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
         }
         else
         {
@@ -2571,7 +2571,7 @@ void DrawClock(bool fromJSON)
         }
     }
 
-    if (!clockFatFont && clockDrawWeekDays)
+    if (!clockFatFont && !clockLargeFont && clockDrawWeekDays)
     {
         DrawWeekDay();
     }

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -293,7 +293,6 @@ uint8_t clockColorR = 255, clockColorG = 255, clockColorB = 255;
 uint clockAutoFallbackTime = 30;
 bool forceClock = false;
 bool clockBlinkAnimated = true;
-uint clockFontChoise = 2;
 bool clockLargeFont = false;
 bool clockFatFont = false;
 bool clockDrawWeekDays = true;
@@ -2415,7 +2414,18 @@ void DrawClock(bool fromJSON)
 
     int xPosTime = 0;
 
-    // check if a large font is in use
+    // use Adafruit 7px font as large clock font by default
+    uint clockFontChoice = 1;
+    if (clockFatFont) // use fat 8px clock font if set explicitly
+    {
+        clockFontChoice = 2;
+    }
+    else if (clockLargeFont) // use large 8px clock font if set explicitly
+    {
+        clockFontChoice = 3;
+    }
+
+    // check if a large font is set
     bool clockFontIsLarge = false;
     if (clockLargeFont || clockFatFont)
     {
@@ -2487,20 +2497,16 @@ void DrawClock(bool fromJSON)
         {
             clockCounterClock++;
         }
-        if (clockLargeFont) // use non-bold font
-        {
-            clockFontChoise = 3;
-        }
         if (clockCounterClock > clockSwitchSec)
         {
             clockCounterDate = 0;
 
             if (clockFontIsLarge) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
             {
-                DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
+                DrawTextCenter(String(time), clockFontChoice, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeOut(30);
                 matrix->clear();
-                DrawTextCenter(String(date), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
+                DrawTextCenter(String(date), clockFontChoice, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeIn(30);
             }
             else
@@ -2525,7 +2531,7 @@ void DrawClock(bool fromJSON)
         else if (clockFontIsLarge)
         {
 
-            DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
+            DrawTextCenter(String(time), clockFontChoice, clockColorR, clockColorG, clockColorB, 0, 1);
         }
         else
         {
@@ -2570,7 +2576,7 @@ void DrawClock(bool fromJSON)
         }
         else if (clockFontIsLarge)
         {
-            DrawTextCenter(String(date), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
+            DrawTextCenter(String(date), clockFontChoice, clockColorR, clockColorG, clockColorB, 0, 1);
         }
         else
         {

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -293,6 +293,8 @@ uint8_t clockColorR = 255, clockColorG = 255, clockColorB = 255;
 uint clockAutoFallbackTime = 30;
 bool forceClock = false;
 bool clockBlinkAnimated = true;
+uint clockFontChoise = 2;
+bool clockLargeFont = false;
 bool clockFatFont = false;
 bool clockDrawWeekDays = true;
 
@@ -517,6 +519,7 @@ void SaveConfig()
     json["clockDateDayMonth"] = clockDateDayMonth;
     json["clockDayOfWeekFirstMonday"] = clockDayOfWeekFirstMonday;
     json["clockBlinkAnimated"] = clockBlinkAnimated;
+    json["clockLargeFont"] = clockLargeFont;
     json["clockFatFont"] = clockFatFont;
     json["clockDrawWeekDays"] = clockDrawWeekDays;
     json["scrollTextDefaultDelay"] = scrollTextDefaultDelay;
@@ -746,11 +749,15 @@ void SetConfigVariables(JsonObject &json)
         clockDayOfWeekFirstMonday = json["clockDayOfWeekFirstMonday"].as<bool>();
     }
 
+    if (json.containsKey("clockLargeFont"))
+    {
+        clockLargeFont = json["clockLargeFont"].as<bool>();
+    }
+
     if (json.containsKey("clockFatFont"))
     {
         clockFatFont = json["clockFatFont"].as<bool>();
     }
-
     if (json.containsKey("clockDrawWeekDays"))
     {
         clockDrawWeekDays = json["clockDrawWeekDays"].as<bool>();
@@ -1559,7 +1566,12 @@ void CreateFrames(JsonObject &json, int forceDuration)
                 logMessage += F("fatFont, ");
                 clockFatFont = json["clock"]["fatFont"];
             }
-
+            bool isLargeFontSet = json["clock"]["largeFont"].is<bool>();
+            if (isLargeFontSet)
+            {
+                logMessage += F("largeFont, ");
+                clockLargeFont = json["clock"]["largeFont"];
+            }
             bool isDrawWeekDaysSet = json["clock"]["drawWeekDays"].is<bool>();
             if (isDrawWeekDaysSet)
             {
@@ -2169,10 +2181,21 @@ void DrawTextHelper(String text, int bigFont, bool centerText, bool scrollText, 
         // Position correction
         posY = posY - 1;
     }
-    else if (bigFont == 2) // very large font, only to be used for time display / very large font, only for the time display
+    else if (bigFont == 2) // fat font, only to be used for time display
+    {
+        // Set fat font
+        matrix->setFont(&FatPixels);
+
+        matrix->getTextBounds(text, 0, 0, &boundsx1, &boundsy1, &boundsw, &boundsh);
+        xTextWidth = boundsw;
+
+        // Position correction
+        posY = posY + 6;
+    }
+    else if (bigFont == 3) // very large font, only to be used for time display
     {
         // Set very large font
-        matrix->setFont(&FatPixels);
+        matrix->setFont(&LargePixels);
 
         matrix->getTextBounds(text, 0, 0, &boundsx1, &boundsy1, &boundsw, &boundsh);
         xTextWidth = boundsw;
@@ -2457,17 +2480,20 @@ void DrawClock(bool fromJSON)
         {
             clockCounterClock++;
         }
-
+        if (clockLargeFont) // use non-bold font
+        {
+            clockFontChoise = 3;
+        }
         if (clockCounterClock > clockSwitchSec)
         {
             clockCounterDate = 0;
 
             if (clockFatFont) // fade rather than vertical animate purely because DrawTextCenter doesnt have a Y argument...
             {
-                DrawTextCenter(String(time), 2, clockColorR, clockColorG, clockColorB, 0, 1);
+                DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeOut(30);
                 matrix->clear();
-                DrawTextCenter(String(date), 2, clockColorR, clockColorG, clockColorB, 0, 1);
+                DrawTextCenter(String(date), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
                 FadeIn(30);
             }
             else
@@ -2492,7 +2518,7 @@ void DrawClock(bool fromJSON)
         else if (clockFatFont)
         {
 
-            DrawTextCenter(String(time), 2, clockColorR, clockColorG, clockColorB, 0, 1);
+            DrawTextCenter(String(time), clockFontChoise, clockColorR, clockColorG, clockColorB, 0, 1);
         }
         else
         {

--- a/src/PixelItFont.h
+++ b/src/PixelItFont.h
@@ -476,6 +476,57 @@ const GFXglyph PixelItGlyphs[] PROGMEM = {
 
 const GFXfont PixelItFont PROGMEM = {(uint8_t *)PixelItBitmaps, (GFXglyph *)PixelItGlyphs, 0x20, 0xE9, 6};
 
+const uint8_t LargePixels_Bitmaps[] PROGMEM = {
+    //                                ASCII code and symbol
+    0x00,                         //  0x20 ' '
+    0x80,                         //  0x21 '!'
+    0x74, 0x63, 0x18, 0xC6, 0x2E, //  0x30 '0'
+    0x59, 0x24, 0x97,             //  0x31 '1'
+    0x74, 0x42, 0x22, 0x22, 0x1F, //  0x32 '2'
+    0x74, 0x42, 0x60, 0x86, 0x2E, //  0x33 '3'
+    0x19, 0x53, 0x1F, 0x84, 0x21, //  0x34 '4'
+    0xFC, 0x21, 0xE0, 0x86, 0x2E, //  0x35 '5'
+    0x74, 0x61, 0xE8, 0xC6, 0x2E, //  0x36 '6'
+    0xF8, 0x42, 0x22, 0x21, 0x08, //  0x37 '7'
+    0x74, 0x62, 0xE8, 0xC6, 0x2E, //  0x38 '8'
+    0x74, 0x63, 0x17, 0x86, 0x2E, //  0x39 '9'
+    0x90                          //  0x3A ':'
+};
+
+// {offset, width, height, advance cursor, x offset, y offset}
+const GFXglyph LargePixels_Glyphs[] PROGMEM = {
+    //                       ASCII code and symbol
+    {0, 1, 1, 2, 0, -5},  // 0x20 ' '
+    {0, 0, 0, 0, 0, 0},   // 0x21 '!'
+    {0, 0, 0, 0, 0, 0},   // 0x22 '"'
+    {0, 0, 0, 0, 0, 0},   // 0x23 '#'
+    {0, 0, 0, 0, 0, 0},   // 0x24 '$'
+    {0, 0, 0, 0, 0, 0},   // 0x25 '%'
+    {0, 0, 0, 0, 0, 0},   // 0x26 '&'
+    {0, 0, 0, 0, 0, 0},   // 0x27 '''
+    {0, 0, 0, 0, 0, 0},   // 0x28 '('
+    {0, 0, 0, 0, 0, 0},   // 0x29 ')'
+    {0, 0, 0, 0, 0, 0},   // 0x2A '*'
+    {0, 0, 0, 0, 0, 0},   // 0x2B '+'
+    {0, 0, 0, 0, 0, 0},   // 0x2C ','
+    {0, 0, 0, 0, 0, 0},   // 0x2D '-'
+    {1, 1, 1, 2, 0, 0},   // 0x2E '.'
+    {0, 0, 0, 0, 0, 0},   // 0x2F '/'
+    {2, 5, 8, 6, 0, -7},  // 0x30 '0'
+    {7, 3, 8, 4, 0, -7},  // 0x31 '1'
+    {10, 5, 8, 6, 0, -7}, // 0x32 '2'
+    {15, 5, 8, 6, 0, -7}, // 0x33 '3'
+    {20, 5, 8, 6, 0, -7}, // 0x34 '4'
+    {25, 5, 8, 6, 0, -7}, // 0x35 '5'
+    {30, 5, 8, 6, 0, -7}, // 0x36 '6'
+    {35, 5, 8, 6, 0, -7}, // 0x37 '7'
+    {40, 5, 8, 6, 0, -7}, // 0x38 '8'
+    {45, 5, 8, 6, 0, -7}, // 0x39 '9'
+    {50, 1, 4, 2, 0, -5}  // 0x3A ':'
+};
+
+const GFXfont LargePixels PROGMEM = {(uint8_t *)LargePixels_Bitmaps, (GFXglyph *)LargePixels_Glyphs, 0x20, 0x3A, 8};
+
 const uint8_t FatPixels_Bitmaps[] PROGMEM = {
     //                                ASCII code and symbol
     0x00,                         //  0x20 ' '


### PR DESCRIPTION
Currently the clock display can use a 5px or 7px font or the bold 8px one which is not very readable. This PR adds a new non-bold 8px large font:
![image](https://github.com/pixelit-project/PixelIt/assets/2088123/3121f279-f1a9-4f8d-b70a-31976eddd48c)

This PR is a replacement for #311 and covers the the backend part for the board itself.

The Fat font is rendered when `bigFont == 2` while the new one uses `bigFont == 3`. This is set when `clockLargeFont` is true. Adding this flag is what remains for the UI repo and is handled via https://github.com/pixelit-project/PixelIt.WebUI/pull/15

Looking forward for feedback.

