### PR TITLE
ESP32-C3 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,30 +16,21 @@ extra_scripts = pre:extra_script.py
 build_flags =
 	-DMATRIX_WIDTH=32 ; Pixel cols
 	-DMATRIX_HEIGHT=8 ; Pixel rows
+	-DLDR_PIN=A0
+	-DDEFAULT_PIN_SCL="Pin_D1"
+	-DDEFAULT_PIN_SDA="Pin_D3"
+	-DDEFAULT_PIN_DFPRX="Pin_D7"
+	-DDEFAULT_PIN_DFPTX="Pin_D8"
+	-DDEFAULT_PIN_ONEWIRE="Pin_D1"
+	-DDEFAULT_MATRIX_TYPE=1
+	-DDEFAULT_LDR=GL5516
+	-DVBAT_PIN=0
 esp32_build_flags = 
 	${common.build_flags}
-	-DLDR_PIN=A0
 	-DMATRIX_PIN=27
-	-DDEFAULT_PIN_SCL="Pin_D1"
-	-DDEFAULT_PIN_SDA="Pin_D3"
-	-DDEFAULT_PIN_DFPRX="Pin_D7"
-	-DDEFAULT_PIN_DFPTX="Pin_D8"
-	-DDEFAULT_PIN_ONEWIRE="Pin_D1"
-	-DDEFAULT_MATRIX_TYPE=1
-	-DDEFAULT_LDR=GL5516
-	-DVBAT_PIN=0
 esp8266_build_flags =
 	${common.build_flags}
- 	-DLDR_PIN=A0
 	-DMATRIX_PIN=D2
-	-DDEFAULT_PIN_SCL="Pin_D1"
-	-DDEFAULT_PIN_SDA="Pin_D3"
-	-DDEFAULT_PIN_DFPRX="Pin_D7"
-	-DDEFAULT_PIN_DFPTX="Pin_D8"
-	-DDEFAULT_PIN_ONEWIRE="Pin_D1"
-	-DDEFAULT_MATRIX_TYPE=1
-	-DDEFAULT_LDR=GL5516
-	-DVBAT_PIN=0
 lib_deps = 
 	adafruit/Adafruit BME280 Library@^2.0.2
 	adafruit/Adafruit BME680 Library@^2.0.1
@@ -140,3 +131,24 @@ build_flags =
 	-DMIN_BATTERY=475
 	-DMAX_BATTERY=665
 	-DBUILD_SECTION="ESP32_ulanzi"
+
+[env:ESP32C3_generic]
+platform = espressif32
+board = seeed_xiao_esp32c3
+framework = ${common.framework}
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+upload_speed = ${common.upload_speed}
+build_flags =
+ 	${common.esp32_build_flags}
+	-DMATRIX_PIN=D2
+	-DBUILD_SECTION="ESP32C3_generic"
+platform_packages = 
+ 	framework-arduinoespressif32 
+ 	toolchain-riscv-esp
+lib_deps = 
+	${common.lib_deps}
+	fastled/FastLED@^3.6.0
+	Hash = https://github.com/bbx10/Hash_tng.git
+	plerup/EspSoftwareSerial@^8.1.0
+	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.16-rc.2

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,6 +28,9 @@ build_flags =
 esp32_build_flags = 
 	${common.build_flags}
 	-DMATRIX_PIN=27
+esp32c3_build_flags = 
+	${common.build_flags}
+	-DMATRIX_PIN=D2
 esp8266_build_flags =
 	${common.build_flags}
 	-DMATRIX_PIN=D2
@@ -140,8 +143,7 @@ monitor_speed = ${common.monitor_speed}
 extra_scripts = ${common.extra_scripts}
 upload_speed = ${common.upload_speed}
 build_flags =
- 	${common.esp32_build_flags}
-	-DMATRIX_PIN=D2
+ 	${common.esp32c3_build_flags}
 	-DBUILD_SECTION="ESP32C3_generic"
 platform_packages = 
  	framework-arduinoespressif32 

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -3494,6 +3494,47 @@ uint8_t TranslatePin(String pin)
         return 27;
     Log(F("Pin assignment - unknown pin"), pin);
     return LED_BUILTIN;
+
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+    if (pin == "Pin_D0")
+        return D0;
+    if (pin == "Pin_D1")
+        return D1;
+    if (pin == "Pin_D2")
+        return D2;
+    if (pin == "Pin_D3")
+        return D3;
+    if (pin == "Pin_D4")
+        return D4;
+    if (pin == "Pin_D5")
+        return D5;
+    if (pin == "Pin_D6")
+        return D6;
+    if (pin == "Pin_D7")
+        return D7;
+    if (pin == "Pin_D8")
+        return D8;
+    if (pin == "GPIO_NUM_14")
+        return GPIO_NUM_14;
+    if (pin == "GPIO_NUM_15")
+        return GPIO_NUM_15;
+    if (pin == "GPIO_NUM_16")
+        return GPIO_NUM_16;
+    if (pin == "GPIO_NUM_17")
+        return GPIO_NUM_17;
+    if (pin == "GPIO_NUM_18")
+        return GPIO_NUM_18;
+    if (pin == "GPIO_NUM_19")
+        return GPIO_NUM_19;
+    if (pin == "GPIO_NUM_21")
+        return GPIO_NUM_21;
+    if (pin == "SPI_CLK_GPIO_NUM")
+        return SPI_CLK_GPIO_NUM;
+    if (pin == "SPI_CS0_GPIO_NUM")
+        return SPI_CS0_GPIO_NUM;
+    Log(F("Pin assignment - unknown pin"), pin);
+    return GPIO_NUM_NC;
+
 #elif defined(ESP32)
 
     if (pin == "GPIO_NUM_14")


### PR DESCRIPTION
Add support for ESP32-C3 RISC-V MCU. Mostly re-use ESP32 code with a dedicated pin definition section since this MCU has less GPIO pins.

Also used the latest libraries for this module, this may be applied to other boards as well.

Tested on a ESP32-C3 SuperMini board.