### PR TITLE
ESP32: use FastLED version from lib_deps

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -79,7 +79,6 @@ platform_packages =
  	toolchain-xtensa32@~2.80400.0
 lib_deps = 
 	${common.lib_deps}
-	fastled/FastLED@^3.5.0	
 	Hash = https://github.com/bbx10/Hash_tng.git
 	plerup/EspSoftwareSerial@^6.11.4
 	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1


### PR DESCRIPTION
Remove FastLED library version override present on ESP32_generic target.
Use version specified in `common.lib_deps` instead (currently 3.7.0 vs 3.5.0)
