### PR TITLE
Upgrade SDK for esp8266, use common library versions for all targets

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -79,7 +79,6 @@ platform_packages =
  	toolchain-xtensa32@~2.80400.0
 lib_deps = 
 	${common.lib_deps}
-	fastled/FastLED@^3.5.0	
 	Hash = https://github.com/bbx10/Hash_tng.git
 	plerup/EspSoftwareSerial@^6.11.4
 	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1

--- a/platformio.ini
+++ b/platformio.ini
@@ -53,15 +53,17 @@ lib_deps =
 	bblanchon/ArduinoJson@5.13.4
 	beegee-tokyo/DHT sensor library for ESPx@1.19.0
 	claws/BH1750@1.3.0
-	ColorConverter=https://github.com/luisllamasbinaburo/Arduino-ColorConverter.git#v2.0.0
 	fastled/FastLED@3.7.0
 	knolleary/PubSubClient@2.8.0
+	Hash = https://github.com/bbx10/Hash_tng.git
 	LightDependentResistor=https://github.com/QuentinCG/Arduino-Light-Dependent-Resistor-Library.git#1.4.0
 	links2004/WebSockets@2.4.1
 	marcmerlin/FastLED NeoMatrix@1.2.0
 	powerbroker2/DFPlayerMini_Fast@1.2.4
+	plerup/EspSoftwareSerial@^8.2.0
 	robtillaart/Max44009@0.6.0
 	TimeLib = https://github.com/PaulStoffregen/Time.git#v1.6.1
+	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.17
 
 [env:ESP32_generic]
 platform = espressif32
@@ -79,12 +81,9 @@ platform_packages =
  	toolchain-xtensa32@~2.80400.0
 lib_deps = 
 	${common.lib_deps}
-	Hash = https://github.com/bbx10/Hash_tng.git
-	plerup/EspSoftwareSerial@^6.11.4
-	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.15-rc.1
 
 [env:ESP8266_generic]
-platform = espressif8266@2.6.3
+platform = espressif8266@4.2.1
 board = esp12e
 framework = ${common.framework}
 board_build.filesystem = littlefs
@@ -96,8 +95,6 @@ build_flags =
 	-DBUILD_SECTION="ESP8266_generic"
 lib_deps = 
 	${common.lib_deps}
-	mr-glt/SHA-1 Hash@^1.1.0
-	tzapu/WiFiManager@^0.16.0
 
 [env:ESP8266_d1_mini]
 extends = env:ESP8266_generic

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ lib_deps =
 	claws/BH1750@1.3.0
 	fastled/FastLED@3.7.0
 	knolleary/PubSubClient@2.8.0
-	Hash = https://github.com/bbx10/Hash_tng.git
+	Hash = https://github.com/bbx10/Hash_tng.git#1f100823284a28e8aedeae7e7f593e189fe16982
 	LightDependentResistor=https://github.com/QuentinCG/Arduino-Light-Dependent-Resistor-Library.git#1.4.0
 	links2004/WebSockets@2.4.1
 	marcmerlin/FastLED NeoMatrix@1.2.0


### PR DESCRIPTION
This PR fixes #359 which required also bumping the SDK version for esp8266 to the latest version supported by PlatformIO and adjusting the code base accordingly.

Notable changes:
* `espressif8266 4.2.1` core used
* `EspSoftwareSerial 8.2.0` used for all targets
* `WiFiManager v2.0.17` used for all targets
* `Hash_tng` used for all targets since the code is mostly identical to `mr-glt/SHA-1`
* `ColorConverter` removed due to bugs, `RgbToHex` and `HexToRgb` functions re-created locally
* `webSocket.sendTXT` invocations fixed due to compiler errors on new SDK

Tested to work on a esp8266 board and an Ulanzi clock