### PR TITLE
Use ESP32 SDK v2.0.17

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,8 +77,7 @@ build_flags =
  	${common.esp32_build_flags}
 	-DBUILD_SECTION="ESP32_generic"
 platform_packages = 
- 	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.14
- 	toolchain-xtensa32@~2.80400.0
+ 	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.17
 lib_deps = 
 	${common.lib_deps}
 


### PR DESCRIPTION
Use ESP32 SDK v2.0.17 instead of v2.0.14

Also, remove `toolchain-xtensa32` from `platform_packages` since it does not seem to be used either way producing the same result. See build logs below.

With toolchain-xtensa32:
```
PACKAGES: 
 - framework-arduinoespressif32 @ 2.0.17+sha.5e19e08 
 - tool-esptoolpy @ 1.40501.0 (4.5.1) 
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch5 
 - toolchain-xtensa32 @ 2.80400.210211 (8.4.0)
...
RAM:   [==        ]  16.7% (used 54760 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1139417 bytes from 1310720 bytes)
Building .pio/build/ESP32_ulanzi/firmware_v0.0.0-beta_ESP32_ulanzi.bin
```

Without toolchain-xtensa32:
```
PACKAGES: 
 - framework-arduinoespressif32 @ 2.0.17+sha.5e19e08 
 - tool-esptoolpy @ 1.40501.0 (4.5.1) 
 - toolchain-xtensa-esp32 @ 8.4.0+2021r2-patch5
...
RAM:   [==        ]  16.7% (used 54760 bytes from 327680 bytes)
Flash: [========= ]  86.9% (used 1139417 bytes from 1310720 bytes)
Building .pio/build/ESP32_ulanzi/firmware_v0.0.0-beta_ESP32_ulanzi.bin
```

Resulting binaries are identical, checksums are different only due to the timestamp:

```
diff <(hexdump -C odl.elf) <(hexdump -C new.elf) 
2126,2127c2126,2127
< 000094c0  75 67 20 32 39 20 32 30  32 34 20 31 37 3a 30 30  |ug 29 2024 17:00|
< 000094d0  3a 32 35 00 5b 4d 45 4d  5d 20 66 72 65 65 3a 20  |:25.[MEM] free: |
---
> 000094c0  75 67 20 32 39 20 32 30  32 34 20 31 36 3a 35 38  |ug 29 2024 16:58|
> 000094d0  3a 35 35 00 5b 4d 45 4d  5d 20 66 72 65 65 3a 20  |:55.[MEM] free: |
```

New firmware tested on an Ulanzi clock and working as expected