### PR TITLE
Bug esp8266 interupt

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -28,7 +28,7 @@
 #include <PubSubClient.h>
 // Matrix
 #if defined(ESP8266)
-#define FASTLED_INTERRUPT_RETRY_COUNT 0
+#define FASTLED_INTERRUPT_RETRY_COUNT 0     //Since espresif version 3, this is required for esp 8266.
 #endif
 #include <Wire.h>
 #include <Adafruit_GFX.h>
@@ -1072,17 +1072,17 @@ void SleepScreen(bool startSleep, bool forceClockOnWake)
         Log(F("SleepScreen"), F("Sleeping..."));
         matrix->clear();
         DrawTextHelper("z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) - 6, 1);
-        matrix->show();
+        FastLED.show();
         delay(200);
         DrawTextHelper("Z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) - 1, 1);
-        matrix->show();
+        FastLED.show();
         delay(200);
         DrawTextHelper("z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) + 4, 1);
-        matrix->show();
+        FastLED.show();
         delay(500);
         FadeOut(30, 0);
         matrix->setBrightness(0);
-        matrix->show();
+        FastLED.show();
     }
     else
     {
@@ -1365,7 +1365,7 @@ void CreateFrames(JsonObject &json, int forceDuration)
             sendMatrixInfo = true;
             currentMatrixBrightness = json["brightness"].as<int>();
             matrix->setBrightness(currentMatrixBrightness);
-            matrix->show();
+            FastLED.show();
         }
     }
 
@@ -1854,7 +1854,7 @@ void CreateFrames(JsonObject &json, int forceDuration)
         {
             // Fade nicht aktiv!
             // Muss mich selbst um Show kümmern
-            matrix->show();
+            FastLED.show();
         }
     }
 
@@ -2314,7 +2314,7 @@ void DrawTextHelper(String text, int bigFont, bool centerText, bool scrollText, 
         }
         else
         {
-            matrix->show();
+            FastLED.show();
         }
     }
     else
@@ -2350,7 +2350,7 @@ void ScrollText(bool isFadeInRequired)
         }
         else
         {
-            matrix->show();
+            FastLED.show();
         }
     }
     else
@@ -2434,7 +2434,7 @@ void AnimateBMP(bool isShowRequired)
 
     if (isShowRequired)
     {
-        matrix->show();
+        FastLED.show();
     }
 }
 
@@ -2584,7 +2584,7 @@ void DrawClock(bool fromJSON)
                     {
                         DrawWeekDay();
                     }
-                    matrix->show();
+                    FastLED.show();
                     delay(35);
                 }
             }
@@ -2630,7 +2630,7 @@ void DrawClock(bool fromJSON)
                     {
                         DrawWeekDay();
                     }
-                    matrix->show();
+                    FastLED.show();
                     delay(35);
                 }
             }
@@ -2654,7 +2654,7 @@ void DrawClock(bool fromJSON)
     // muss ich mich selbst ums Show kümmern.
     if (!fromJSON)
     {
-        matrix->show();
+        FastLED.show();
     }
 }
 
@@ -3155,7 +3155,7 @@ void FadeOut(int dealy, int minBrightness)
     {
         currentFadeBrightness = map(counter, 0, 25, minBrightness, currentMatrixBrightness);
         matrix->setBrightness(currentFadeBrightness);
-        matrix->show();
+        FastLED.show();
         counter--;
         delay(dealy);
     }
@@ -3170,7 +3170,7 @@ void FadeIn(int dealy, int minBrightness)
     {
         currentFadeBrightness = map(counter, 0, 25, minBrightness, currentMatrixBrightness);
         matrix->setBrightness(currentFadeBrightness);
-        matrix->show();
+        FastLED.show();
         counter++;
         delay(dealy);
     }
@@ -3186,7 +3186,7 @@ void ColoredBarWipe()
         matrix->drawFastVLine(i + 1, 0, 8, ColorWheel((i * 9) & 255, 0));
         matrix->drawFastVLine(i - 1, 0, 8, 0);
         matrix->drawFastVLine(i - 2, 0, 8, 0);
-        matrix->show();
+        FastLED.show();
         delay(15);
     }
 }
@@ -3209,7 +3209,7 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
                 matrix->drawFastVLine(32 - col, row, 2, matrix->Color(r, g, b));
                 matrix->drawFastVLine(32 - col - 1, row, 2, matrix->Color(r, g, b));
             }
-            matrix->show();
+            FastLED.show();
             delay(5);
         }
         matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
@@ -3223,12 +3223,12 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
             matrix->drawFastVLine(0, row + 1, 2, matrix->Color(r, g, b));
             matrix->drawFastVLine(1, row + 1, 2, matrix->Color(r, g, b));
         }
-        matrix->show();
+        FastLED.show();
         delay(5);
         matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
     }
     matrix->fillRect(0, 0, 32, 8, matrix->Color(0, 0, 0));
-    matrix->show();
+    FastLED.show();
 }
 
 void BitmapWipe(JsonArray &data, int16_t w)
@@ -3243,10 +3243,10 @@ void BitmapWipe(JsonArray &data, int16_t w)
                 matrix->drawPixel(x + i, y, data[j * w + i].as<uint16_t>());
             }
         }
-        matrix->show();
+        FastLED.show();
         delay(18);
         matrix->fillRect(0, 0, x, 8, matrix->Color(0, 0, 0));
-        matrix->show();
+        FastLED.show();
     }
 }
 
@@ -3259,7 +3259,7 @@ void ColorFlash(int red, int green, int blue)
             matrix->drawPixel(column, row, matrix->Color(red, green, blue));
         }
     }
-    matrix->show();
+    FastLED.show();
 }
 
 uint ColorWheel(byte wheelPos, int pos)
@@ -3283,28 +3283,28 @@ uint ColorWheel(byte wheelPos, int pos)
 void ShowBootAnimation()
 {
     DrawTextHelper("P", false, false, false, false, false, 255, 51, 255, (MATRIX_WIDTH / 2) - 12, 1);
-    matrix->show();
+    FastLED.show();
 
     delay(200);
     DrawTextHelper("I", false, false, false, false, false, 0, 255, 42, (MATRIX_WIDTH / 2) - 8, 1);
-    matrix->show();
+    FastLED.show();
 
     delay(200);
     DrawTextHelper("X", false, false, false, false, false, 255, 25, 25, (MATRIX_WIDTH / 2) - 6, 1);
-    matrix->show();
+    FastLED.show();
 
     delay(200);
     DrawTextHelper("E", false, false, false, false, false, 25, 255, 255, (MATRIX_WIDTH / 2) - 2, 1);
-    matrix->show();
+    FastLED.show();
 
     delay(200);
     DrawTextHelper("L", false, false, false, false, false, 255, 221, 51, (MATRIX_WIDTH / 2) + 2, 1);
-    matrix->show();
+    FastLED.show();
 
     delay(500);
     DrawTextHelper("I", false, false, false, false, false, 255, 255, 255, (MATRIX_WIDTH / 2) + 6, 1);
     DrawTextHelper("T", false, false, false, false, false, 255, 255, 255, (MATRIX_WIDTH / 2) + 8, 1);
-    matrix->show();
+    FastLED.show();
     delay(1000);
 }
 
@@ -3326,7 +3326,7 @@ void ShowBatteryScreen()
     matrix->clear();
     DrawSingleBitmap(root["bitmap"]);
     DrawTextHelper(String(batteryLevel, 0) + "%", false, true, false, false, false, 255, 255, 255, 9, 1);
-    matrix->show();
+    FastLED.show();
     delay(1000);
 }
 
@@ -4159,7 +4159,7 @@ void loop()
             {
                 SetCurrentMatrixBrightness(newBrightness);
                 Log(F("Auto Brightness"), "Lux: " + String(currentLux) + " set brightness to " + String(currentMatrixBrightness));
-                matrix->show();
+                FastLED.show();
             }
         }
     }

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -28,7 +28,7 @@
 #include <PubSubClient.h>
 // Matrix
 #if defined(ESP8266)
-#define FASTLED_INTERRUPT_RETRY_COUNT 0     //Since espresif version 3, this is required for esp 8266.
+#define FASTLED_INTERRUPT_RETRY_COUNT 0 // Since espresif version 3, this is required for esp 8266.
 #endif
 #include <Wire.h>
 #include <Adafruit_GFX.h>
@@ -396,6 +396,12 @@ String ResetReason()
         return "Unknown reset reason";
     }
 #endif
+}
+
+void matrixShow()
+{
+    FastLED.delay(5);
+    FastLED.show();
 }
 
 Version parseVersion(const char *versionStr)
@@ -1072,17 +1078,17 @@ void SleepScreen(bool startSleep, bool forceClockOnWake)
         Log(F("SleepScreen"), F("Sleeping..."));
         matrix->clear();
         DrawTextHelper("z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) - 6, 1);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         delay(200);
         DrawTextHelper("Z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) - 1, 1);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         delay(200);
         DrawTextHelper("z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) + 4, 1);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         delay(500);
         FadeOut(30, 0);
         matrix->setBrightness(0);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
     }
     else
     {
@@ -1365,7 +1371,7 @@ void CreateFrames(JsonObject &json, int forceDuration)
             sendMatrixInfo = true;
             currentMatrixBrightness = json["brightness"].as<int>();
             matrix->setBrightness(currentMatrixBrightness);
-            FastLED.delay(5); FastLED.show();
+            matrixShow();
         }
     }
 
@@ -1854,7 +1860,7 @@ void CreateFrames(JsonObject &json, int forceDuration)
         {
             // Fade nicht aktiv!
             // Muss mich selbst um Show kümmern
-            FastLED.delay(5); FastLED.show();
+            matrixShow();
         }
     }
 
@@ -2314,7 +2320,7 @@ void DrawTextHelper(String text, int bigFont, bool centerText, bool scrollText, 
         }
         else
         {
-            FastLED.delay(5); FastLED.show();
+            matrixShow();
         }
     }
     else
@@ -2350,7 +2356,7 @@ void ScrollText(bool isFadeInRequired)
         }
         else
         {
-            FastLED.delay(5); FastLED.show();
+            matrixShow();
         }
     }
     else
@@ -2434,7 +2440,7 @@ void AnimateBMP(bool isShowRequired)
 
     if (isShowRequired)
     {
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
     }
 }
 
@@ -2584,7 +2590,7 @@ void DrawClock(bool fromJSON)
                     {
                         DrawWeekDay();
                     }
-                    FastLED.delay(5); FastLED.show();
+                    matrixShow();
                     delay(35);
                 }
             }
@@ -2630,7 +2636,7 @@ void DrawClock(bool fromJSON)
                     {
                         DrawWeekDay();
                     }
-                    FastLED.delay(5); FastLED.show();
+                    matrixShow();
                     delay(35);
                 }
             }
@@ -2654,7 +2660,7 @@ void DrawClock(bool fromJSON)
     // muss ich mich selbst ums Show kümmern.
     if (!fromJSON)
     {
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
     }
 }
 
@@ -3155,7 +3161,7 @@ void FadeOut(int dealy, int minBrightness)
     {
         currentFadeBrightness = map(counter, 0, 25, minBrightness, currentMatrixBrightness);
         matrix->setBrightness(currentFadeBrightness);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         counter--;
         delay(dealy);
     }
@@ -3170,7 +3176,7 @@ void FadeIn(int dealy, int minBrightness)
     {
         currentFadeBrightness = map(counter, 0, 25, minBrightness, currentMatrixBrightness);
         matrix->setBrightness(currentFadeBrightness);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         counter++;
         delay(dealy);
     }
@@ -3186,7 +3192,7 @@ void ColoredBarWipe()
         matrix->drawFastVLine(i + 1, 0, 8, ColorWheel((i * 9) & 255, 0));
         matrix->drawFastVLine(i - 1, 0, 8, 0);
         matrix->drawFastVLine(i - 2, 0, 8, 0);
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         delay(15);
     }
 }
@@ -3209,7 +3215,7 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
                 matrix->drawFastVLine(32 - col, row, 2, matrix->Color(r, g, b));
                 matrix->drawFastVLine(32 - col - 1, row, 2, matrix->Color(r, g, b));
             }
-            FastLED.delay(5); FastLED.show();
+            matrixShow();
             delay(5);
         }
         matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
@@ -3223,12 +3229,12 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
             matrix->drawFastVLine(0, row + 1, 2, matrix->Color(r, g, b));
             matrix->drawFastVLine(1, row + 1, 2, matrix->Color(r, g, b));
         }
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         delay(5);
         matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
     }
     matrix->fillRect(0, 0, 32, 8, matrix->Color(0, 0, 0));
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 }
 
 void BitmapWipe(JsonArray &data, int16_t w)
@@ -3243,10 +3249,10 @@ void BitmapWipe(JsonArray &data, int16_t w)
                 matrix->drawPixel(x + i, y, data[j * w + i].as<uint16_t>());
             }
         }
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
         delay(18);
         matrix->fillRect(0, 0, x, 8, matrix->Color(0, 0, 0));
-        FastLED.delay(5); FastLED.show();
+        matrixShow();
     }
 }
 
@@ -3259,7 +3265,7 @@ void ColorFlash(int red, int green, int blue)
             matrix->drawPixel(column, row, matrix->Color(red, green, blue));
         }
     }
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 }
 
 uint ColorWheel(byte wheelPos, int pos)
@@ -3283,28 +3289,28 @@ uint ColorWheel(byte wheelPos, int pos)
 void ShowBootAnimation()
 {
     DrawTextHelper("P", false, false, false, false, false, 255, 51, 255, (MATRIX_WIDTH / 2) - 12, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 
     delay(200);
     DrawTextHelper("I", false, false, false, false, false, 0, 255, 42, (MATRIX_WIDTH / 2) - 8, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 
     delay(200);
     DrawTextHelper("X", false, false, false, false, false, 255, 25, 25, (MATRIX_WIDTH / 2) - 6, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 
     delay(200);
     DrawTextHelper("E", false, false, false, false, false, 25, 255, 255, (MATRIX_WIDTH / 2) - 2, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 
     delay(200);
     DrawTextHelper("L", false, false, false, false, false, 255, 221, 51, (MATRIX_WIDTH / 2) + 2, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
 
     delay(500);
     DrawTextHelper("I", false, false, false, false, false, 255, 255, 255, (MATRIX_WIDTH / 2) + 6, 1);
     DrawTextHelper("T", false, false, false, false, false, 255, 255, 255, (MATRIX_WIDTH / 2) + 8, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
     delay(1000);
 }
 
@@ -3326,7 +3332,7 @@ void ShowBatteryScreen()
     matrix->clear();
     DrawSingleBitmap(root["bitmap"]);
     DrawTextHelper(String(batteryLevel, 0) + "%", false, true, false, false, false, 255, 255, 255, 9, 1);
-    FastLED.delay(5); FastLED.show();
+    matrixShow();
     delay(1000);
 }
 
@@ -4159,7 +4165,7 @@ void loop()
             {
                 SetCurrentMatrixBrightness(newBrightness);
                 Log(F("Auto Brightness"), "Lux: " + String(currentLux) + " set brightness to " + String(currentMatrixBrightness));
-                FastLED.delay(5); FastLED.show();
+                matrixShow();
             }
         }
     }
@@ -4382,10 +4388,10 @@ void sendNTPpacket(String &address)
     udp.endPacket();
 }
 
-//decode hex string into R G B decimals
-void HexToRgb(String hex, uint8_t& red, uint8_t& green, uint8_t& blue)
+// decode hex string into R G B decimals
+void HexToRgb(String hex, uint8_t &red, uint8_t &green, uint8_t &blue)
 {
-    const char* hexString = (hex[0] == '#') ? hex.c_str() + 1 : hex.c_str();
+    const char *hexString = (hex[0] == '#') ? hex.c_str() + 1 : hex.c_str();
     long number = strtol(hexString, nullptr, 16);
     red = (number >> 16) & 0xFF;
     green = (number >> 8) & 0xFF;
@@ -4396,15 +4402,18 @@ void HexToRgb(String hex, uint8_t& red, uint8_t& green, uint8_t& blue)
 void RgbToHex(uint8_t red, uint8_t green, uint8_t blue, String &hex)
 {
     String redHex = String(red, HEX);
-    if (redHex.length() < 2) {
+    if (redHex.length() < 2)
+    {
         redHex = "0" + redHex;
     }
     String greenHex = String(green, HEX);
-    if (greenHex.length() < 2) {
+    if (greenHex.length() < 2)
+    {
         greenHex = "0" + greenHex;
     }
     String blueHex = String(blue, HEX);
-    if (blueHex.length() < 2) {
+    if (blueHex.length() < 2)
+    {
         blueHex = "0" + blueHex;
     }
     hex = "#" + redHex + greenHex + blueHex;

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -27,6 +27,9 @@
 // MQTT
 #include <PubSubClient.h>
 // Matrix
+#if defined(ESP8266)
+#define FASTLED_INTERRUPT_RETRY_COUNT 0
+#endif
 #include <Wire.h>
 #include <Adafruit_GFX.h>
 #include <FastLED.h>

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -1072,17 +1072,17 @@ void SleepScreen(bool startSleep, bool forceClockOnWake)
         Log(F("SleepScreen"), F("Sleeping..."));
         matrix->clear();
         DrawTextHelper("z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) - 6, 1);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         delay(200);
         DrawTextHelper("Z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) - 1, 1);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         delay(200);
         DrawTextHelper("z", false, false, false, false, false, 0, 0, 255, (MATRIX_WIDTH / 2) + 4, 1);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         delay(500);
         FadeOut(30, 0);
         matrix->setBrightness(0);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
     }
     else
     {
@@ -1365,7 +1365,7 @@ void CreateFrames(JsonObject &json, int forceDuration)
             sendMatrixInfo = true;
             currentMatrixBrightness = json["brightness"].as<int>();
             matrix->setBrightness(currentMatrixBrightness);
-            FastLED.show();
+            FastLED.delay(5); FastLED.show();
         }
     }
 
@@ -1854,7 +1854,7 @@ void CreateFrames(JsonObject &json, int forceDuration)
         {
             // Fade nicht aktiv!
             // Muss mich selbst um Show kümmern
-            FastLED.show();
+            FastLED.delay(5); FastLED.show();
         }
     }
 
@@ -2314,7 +2314,7 @@ void DrawTextHelper(String text, int bigFont, bool centerText, bool scrollText, 
         }
         else
         {
-            FastLED.show();
+            FastLED.delay(5); FastLED.show();
         }
     }
     else
@@ -2350,7 +2350,7 @@ void ScrollText(bool isFadeInRequired)
         }
         else
         {
-            FastLED.show();
+            FastLED.delay(5); FastLED.show();
         }
     }
     else
@@ -2434,7 +2434,7 @@ void AnimateBMP(bool isShowRequired)
 
     if (isShowRequired)
     {
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
     }
 }
 
@@ -2584,7 +2584,7 @@ void DrawClock(bool fromJSON)
                     {
                         DrawWeekDay();
                     }
-                    FastLED.show();
+                    FastLED.delay(5); FastLED.show();
                     delay(35);
                 }
             }
@@ -2630,7 +2630,7 @@ void DrawClock(bool fromJSON)
                     {
                         DrawWeekDay();
                     }
-                    FastLED.show();
+                    FastLED.delay(5); FastLED.show();
                     delay(35);
                 }
             }
@@ -2654,7 +2654,7 @@ void DrawClock(bool fromJSON)
     // muss ich mich selbst ums Show kümmern.
     if (!fromJSON)
     {
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
     }
 }
 
@@ -3155,7 +3155,7 @@ void FadeOut(int dealy, int minBrightness)
     {
         currentFadeBrightness = map(counter, 0, 25, minBrightness, currentMatrixBrightness);
         matrix->setBrightness(currentFadeBrightness);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         counter--;
         delay(dealy);
     }
@@ -3170,7 +3170,7 @@ void FadeIn(int dealy, int minBrightness)
     {
         currentFadeBrightness = map(counter, 0, 25, minBrightness, currentMatrixBrightness);
         matrix->setBrightness(currentFadeBrightness);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         counter++;
         delay(dealy);
     }
@@ -3186,7 +3186,7 @@ void ColoredBarWipe()
         matrix->drawFastVLine(i + 1, 0, 8, ColorWheel((i * 9) & 255, 0));
         matrix->drawFastVLine(i - 1, 0, 8, 0);
         matrix->drawFastVLine(i - 2, 0, 8, 0);
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         delay(15);
     }
 }
@@ -3209,7 +3209,7 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
                 matrix->drawFastVLine(32 - col, row, 2, matrix->Color(r, g, b));
                 matrix->drawFastVLine(32 - col - 1, row, 2, matrix->Color(r, g, b));
             }
-            FastLED.show();
+            FastLED.delay(5); FastLED.show();
             delay(5);
         }
         matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
@@ -3223,12 +3223,12 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
             matrix->drawFastVLine(0, row + 1, 2, matrix->Color(r, g, b));
             matrix->drawFastVLine(1, row + 1, 2, matrix->Color(r, g, b));
         }
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         delay(5);
         matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
     }
     matrix->fillRect(0, 0, 32, 8, matrix->Color(0, 0, 0));
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 }
 
 void BitmapWipe(JsonArray &data, int16_t w)
@@ -3243,10 +3243,10 @@ void BitmapWipe(JsonArray &data, int16_t w)
                 matrix->drawPixel(x + i, y, data[j * w + i].as<uint16_t>());
             }
         }
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
         delay(18);
         matrix->fillRect(0, 0, x, 8, matrix->Color(0, 0, 0));
-        FastLED.show();
+        FastLED.delay(5); FastLED.show();
     }
 }
 
@@ -3259,7 +3259,7 @@ void ColorFlash(int red, int green, int blue)
             matrix->drawPixel(column, row, matrix->Color(red, green, blue));
         }
     }
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 }
 
 uint ColorWheel(byte wheelPos, int pos)
@@ -3283,28 +3283,28 @@ uint ColorWheel(byte wheelPos, int pos)
 void ShowBootAnimation()
 {
     DrawTextHelper("P", false, false, false, false, false, 255, 51, 255, (MATRIX_WIDTH / 2) - 12, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 
     delay(200);
     DrawTextHelper("I", false, false, false, false, false, 0, 255, 42, (MATRIX_WIDTH / 2) - 8, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 
     delay(200);
     DrawTextHelper("X", false, false, false, false, false, 255, 25, 25, (MATRIX_WIDTH / 2) - 6, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 
     delay(200);
     DrawTextHelper("E", false, false, false, false, false, 25, 255, 255, (MATRIX_WIDTH / 2) - 2, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 
     delay(200);
     DrawTextHelper("L", false, false, false, false, false, 255, 221, 51, (MATRIX_WIDTH / 2) + 2, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
 
     delay(500);
     DrawTextHelper("I", false, false, false, false, false, 255, 255, 255, (MATRIX_WIDTH / 2) + 6, 1);
     DrawTextHelper("T", false, false, false, false, false, 255, 255, 255, (MATRIX_WIDTH / 2) + 8, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
     delay(1000);
 }
 
@@ -3326,7 +3326,7 @@ void ShowBatteryScreen()
     matrix->clear();
     DrawSingleBitmap(root["bitmap"]);
     DrawTextHelper(String(batteryLevel, 0) + "%", false, true, false, false, false, 255, 255, 255, 9, 1);
-    FastLED.show();
+    FastLED.delay(5); FastLED.show();
     delay(1000);
 }
 
@@ -4159,7 +4159,7 @@ void loop()
             {
                 SetCurrentMatrixBrightness(newBrightness);
                 Log(F("Auto Brightness"), "Lux: " + String(currentLux) + " set brightness to " + String(currentMatrixBrightness));
-                FastLED.show();
+                FastLED.delay(5); FastLED.show();
             }
         }
     }


### PR DESCRIPTION
Since the update of espressif Framework to V3 there have been problems with the FastLED Lib.
esp8266/Arduino: https://github.com/esp8266/Arduino/issues/8054
FastLED:                 https://github.com/FastLED/FastLED/issues/1237

The whole thing has something to do with the interups in the ESP8266. These have been changed since V3 and are causing problems.  The current workaround is a delay as soon as data is sent to the matrix.

`matrix->show() `-->  `FastLED.delay(5); FastLED.show();`


Firmware works on esp8266 and esp32.

Update:
another Issue:  https://github.com/FastLED/FastLED/issues/1374
https://github.com/FastLED/FastLED/issues/1563