### PR TITLE
Revert esp8266 SDK

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -45,10 +45,10 @@ lib_deps =
 	adafruit/Adafruit BME680 Library@2.0.4
 	adafruit/Adafruit BMP280 Library@2.6.8
 	adafruit/Adafruit BusIO@1.16.1
-	adafruit/Adafruit GFX Library@1.11.9
+	adafruit/Adafruit GFX Library@1.11.11
 	adafruit/Adafruit SHT31 Library@2.2.2
 	adafruit/Adafruit Unified Sensor@1.1.4
-	arduino-libraries/ArduinoHttpClient@0.4.0
+	arduino-libraries/ArduinoHttpClient@0.6.1
 	bakercp/CRC32 @ 2.0.0
 	bblanchon/ArduinoJson@5.13.4
 	beegee-tokyo/DHT sensor library for ESPx@1.19.0
@@ -60,10 +60,8 @@ lib_deps =
 	links2004/WebSockets@2.4.1
 	marcmerlin/FastLED NeoMatrix@1.2.0
 	powerbroker2/DFPlayerMini_Fast@1.2.4
-	plerup/EspSoftwareSerial@^8.2.0
 	robtillaart/Max44009@0.6.0
 	TimeLib = https://github.com/PaulStoffregen/Time.git#v1.6.1
-	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.17
 
 [env:ESP32_generic]
 platform = espressif32
@@ -80,9 +78,11 @@ platform_packages =
  	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.17
 lib_deps = 
 	${common.lib_deps}
+	plerup/EspSoftwareSerial@^8.2.0
+	WiFiManager = https://github.com/tzapu/WiFiManager.git#v2.0.17
 
 [env:ESP8266_generic]
-platform = espressif8266@4.2.1
+platform = espressif8266@2.6.3
 board = esp12e
 framework = ${common.framework}
 board_build.filesystem = littlefs
@@ -94,6 +94,7 @@ build_flags =
 	-DBUILD_SECTION="ESP8266_generic"
 lib_deps = 
 	${common.lib_deps}
+	tzapu/WiFiManager@^0.16.0
 
 [env:ESP8266_d1_mini]
 extends = env:ESP8266_generic


### PR DESCRIPTION
esp8266 SDK version 3.x is unstable causing display update glitches

* Revert back to known working SDK 2.6.3 for esp8266
* Downgrade WifiManager on esp8266 since latest version does not work with SDK 2.x
* Upgrade some minor libraries to newer versions